### PR TITLE
Update manifest.json for Feedly's new cloud service.

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,7 +5,7 @@
 	"description": "Open Feedly Links in Background Tab using shortcut key",
 	"content_scripts": [
 		{
-			"matches": ["http://www.feedly.com/*"],
+			"matches": ["http://www.feedly.com/*", "http://cloud.feedly.com/*"],
 			"js": ["js/keypress.js"]
 		}
 	],
@@ -13,6 +13,7 @@
 	"options_page": "options.html",
 	"permissions": [
 		"http://www.feedly.com/*",
+		"http://cloud.feedly.com/*",
 	    "storage"
 	],
 	"minimum_chrome_version": "21",


### PR DESCRIPTION
Feedly is now at `http://cloud.feedly.com` for me. This pull request should update the extension to apply to pages at this new URL.
