### PR TITLE
Better matcher for feedly

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Want to change your shortcut key?  Simply visit the options page.
 
 Changelog
 ---
+0.6
+* works on all Feedly URL schemes
+
 0.5
 * works for Feedly Pro
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,11 +1,11 @@
 {
 	"name": "Feedly Background Tab",
-	"version": "0.5",
-	"manifest_version": 2,
+	"version": "0.6",
+	"manifest_version": 3,
 	"description": "Open Feedly Links in Background Tab using shortcut key",
 	"content_scripts": [
 		{
-			"matches": ["http://www.feedly.com/*", "http://cloud.feedly.com/*", "https://cloud.feedly.com/*"],
+			"matches": ["*://*.feedly.com/*"],
 			"js": ["js/keypress.js"]
 		}
 	],


### PR DESCRIPTION
Feedly recently changed it's url scheme, and the extension failed to
work. I modified the matcher for the `content_script` to better
represent this and future changes of the url scheme.

This is a great extension! I use it everyday :+1: 
