### PR TITLE
Update selectors for Feedly markup changes

### DIFF
--- a/src/js/keypress.js
+++ b/src/js/keypress.js
@@ -9,10 +9,10 @@
 	 * @type {array}
 	 */
     var selectors = [
-        '.selectedEntry a.title', // the single list /i/latest
-        'a.websiteCallForAction', // home page, card view popup launch (visit website button)
+        '.selected a.title', // the single list /i/latest
+        'a.visitWebsiteButton', // home page, card view popup launch (visit website button)
     ];
-	const LIST_VIEW_URL_SELECTOR = '.selectedEntry a.title';
+	const LIST_VIEW_URL_SELECTOR = '.selected a.title';
 
 	/**
 	 * Main feedlybackgroundtab constructor


### PR DESCRIPTION
Feedly shipped an update that changes the markup and we need to target new selectors. I tested this in my local Chrome but it could probably stand to be tested on at least one more machine.

Fixes #10 