### PR TITLE
Add additional CSS selector to fix #14

### DIFF
--- a/src/js/keypress.js
+++ b/src/js/keypress.js
@@ -9,6 +9,7 @@
 	 * @type {array}
 	 */
     var selectors = [
+    	        'div.selectedEntry a.title',	// title bar for active entry, collapsed or expanded
 		'.selectedEntry a.visitWebsiteButton',	// the button square button on list view
 		'a.visitWebsiteButton'	// the floating one for card view 
     ];


### PR DESCRIPTION
`.visitWebsiteButton` only appears when an article is expanded. `div.selectedEntry a.title` appears more often and provides the same `href`. This seems to get this working in Magazine, Cards, Grouped By Feeds, and [unexpanded] Title Only views.