### PR TITLE
Add new selector for Article view

### DIFF
--- a/src/js/keypress.js
+++ b/src/js/keypress.js
@@ -11,7 +11,8 @@
     var selectors = [
 		'div.selectedEntry a.title',			// title bar for active entry, collapsed or expanded
 		'.selectedEntry a.visitWebsiteButton',	// the button square button on list view
-		'a.visitWebsiteButton',					// the floating one for card view 
+		'.list-entries .selected a.visitWebsiteButton',	// the button square button on list view
+		'a.visitWebsiteButton',					// the floating one for card view
 		'.entry.selected a.title'				// title bar for active entry in React-based collapsed list view
     ];
 	


### PR DESCRIPTION
Feedly just updated its design and this extension now opens first article regardless of currently selected article.

Added selector for a new design. Its for Article view.