### PR TITLE
Add new selector; add 'additional selectors' option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This isn't a donation - it's a loan from you to those in need.  You get paid bac
 Changelog
 ---------
 0.14
-* Fix for new CSS classes. Adds 'additional selectors' option to support quick fixes for future Feedly markup changes (@bbbrrriiiaaannn)
+* Fix for new CSS classes. Adds 'additional selectors' option to support quick fixes for future Feedly markup changes.  Thanks @bbbrrriiiaaannn, @henley-regatta, @hudochenkov!
 
 0.13
 * Fix for another style change.  Thanks @hudochenkov

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ This isn't a donation - it's a loan from you to those in need.  You get paid bac
 
 Changelog
 ---------
+0.14
+* Fix for new CSS classes. Adds 'additional selectors' option to support quick fixes for future Feedly markup changes (@BrianCS)
+
 0.13
 * Fix for another style change.  Thanks @hudochenkov
 

--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ This isn't a donation - it's a loan from you to those in need.  You get paid bac
 Changelog
 ---------
 0.14
-* Fix for new CSS classes. Adds 'additional selectors' option to support quick fixes for future Feedly markup changes (@BrianCS)
+* Fix for new CSS classes. Adds 'additional selectors' option to support quick fixes for future Feedly markup changes (@bbbrrriiiaaannn)
 
 0.13
 * Fix for another style change.  Thanks @hudochenkov
 
 0.12
-* Fix for React-based layouts.  Thanks @BrianCS
+* Fix for React-based layouts.  Thanks @bbbrrriiiaaannn
 
 0.11
-* Fix for scenarios I hadn't thought of - like non-expanded article.  Thanks @BrianCS
+* Fix for scenarios I hadn't thought of - like non-expanded article.  Thanks @bbbrrriiiaaannn
 
 0.10
 * For some instances, the 0.9 fix wasn't working.  Did a fallback for a fix that hopefully fixes this issue

--- a/src/js/keypress.js
+++ b/src/js/keypress.js
@@ -12,10 +12,10 @@
 	var selectors = [
 		'div.selectedEntry a.title',			// title bar for active entry, collapsed or expanded
 		'.selectedEntry a.visitWebsiteButton',	// the button square button on list view
-		'.list-entries .selected a.visitWebsiteButton',	// the button square button on list view
+		'.list-entries .inlineFrame--selected a.visitWebsiteButton',	// the button square button on list view
 		'a.visitWebsiteButton',					// the floating one for card view
 		'.entry.selected a.title',				// title bar for active entry in React-based collapsed list view
-		'.entry--selected .entry__title', // 2021 Block-Element-Modifier class syntax update
+		'.list-entries .entry--selected .entry__title', // 2021 Block-Element-Modifier class syntax update
 	];
 	
 	/**

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Feedly Background Tab",
-	"version": "0.13",
+	"version": "0.14",
 	"manifest_version": 2,
 	"description": "Open Feedly Links in Background Tab using shortcut key",
 	"content_scripts": [

--- a/src/options.html
+++ b/src/options.html
@@ -32,12 +32,17 @@
         #fbt_container h1 {
             margin-top: 0px;
         }
+        input.settingvalue {
+            font-size: 20px;
+            padding: 3px 5px;
+        }
         #fbt_shortcutkey {
             width: 20px;
-            padding: 3px 5px;
             font-weight: bold;
-            font-size: 20px;
             text-align: center;
+        }
+        #fbt_selector {
+            width:200px;
         }
         #fbt_status {
             font-weight: bold;
@@ -65,7 +70,11 @@
         <p>The following settings are used to modify the behavior of this extension.  Please click <strong>save</strong> when you have finished changing your settings.</p>
         <div>
             <label for="fbt_shortcutkey">Shortcut key:</label>
-            <input type="text" maxlength="1" id="fbt_shortcutkey">
+            <input type="text" maxlength="1" id="fbt_shortcutkey" class="settingvalue" />
+        </div>
+        <div>
+            <label for="fbt_selectors">Additional selectors:</label>
+            <input type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" id="fbt_selector" class="settingvalue" />
         </div>
         <div>
             <button id="fbt_submitbutton">Save</button>


### PR DESCRIPTION
Feedly updated classes targeting unexpanded items in their 'Title-Only View', so this adds `.entry--selected .entry__title` to possible selectors.

This also adds an 'Additional selectors' field in options, where users can add any arbitrary [valid] CSS selector—when everything is working as expected this doesn't offer much utility, but offers a low-ish effort quick fix way to accommodate future feedly.com markup changes.

If nothing else it lets me quickly test future selector additions without having to remember how to load the unpacked extension first. Could likely use some more description in README or on the options page—not obvious how to use it as is (though validation should keep users from breaking their extension through experimenting)

This also shuffles `keyPressHandler` logic around—functionally the same but takes the approach of joining all selectors into a single CSS query at init time.